### PR TITLE
feat: use site metadata, style and CMS tweaks

### DIFF
--- a/sanity/schemas/callout.js
+++ b/sanity/schemas/callout.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default {
   title: 'Callout Block',
   name: 'callout',
@@ -8,4 +10,11 @@ export default {
       type: 'calloutContent',
     },
   ],
+  preview: {
+    component: () => (
+      <p style={{ margin: 0, padding: '1rem' }}>
+        Callout section — hover for editing controls
+      </p>
+    ),
+  },
 };

--- a/sanity/schemas/page.js
+++ b/sanity/schemas/page.js
@@ -1,5 +1,5 @@
 export default {
-  title: 'Page',
+  title: 'Pages',
   name: 'page',
   type: 'document',
   fields: [

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -5,6 +5,40 @@ require('dotenv').config({
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
+  siteMetadata: {
+    title: 'Gatsby Theme Jam',
+    description: 'The Gatsby Theme Jam is a... TKTK',
+    footer: {
+      blurb: `
+        Gatsby is a modern website framework that builds performance into every
+        website by leveraging the latest web technologies. Create blazing fast,
+        compelling apps and websites without needing to become a
+        performance expert.
+      `,
+      links: [
+        {
+          icon: null,
+          name: 'gatsbyjs.org',
+          link: 'https://gatsbyjs.org',
+        },
+        {
+          icon: 'github',
+          name: 'github.com/gatsbyjs',
+          link: 'https://github.com/gatsbyjs',
+        },
+        {
+          icon: 'twitter',
+          name: 'twitter.com/gatsbyjs',
+          link: 'https://twitter.com/gatsbyjs',
+        },
+        {
+          icon: null,
+          name: 'Terms of Use',
+          link: 'https://gatsbyjs.com/terms-of-use',
+        },
+      ],
+    },
+  },
   plugins: ['gatsby-plugin-react-helmet'],
   __experimentalThemes: [
     // {

--- a/site/src/components/Callout.js
+++ b/site/src/components/Callout.js
@@ -9,18 +9,17 @@ const Callout = ({ node }) => {
         position: `relative`,
         backgroundColor: `#FCFAFF`,
         minHeight: `100px`,
-        // these will need to change
-        marginTop: `8rem`,
-        marginBottom: `8rem`,
-        // --------------------
-        padding: `4rem`,
+        marginTop: 6,
+        marginBottom: 6,
+        padding: 5,
         textAlign: `left`,
         '&::before': {
           position: `absolute`,
           zIndex: `-1`,
           width: `100px`,
           height: `100px`,
-          transform: `translate(-5.75rem,-5.75rem)`,
+          right: 0,
+          transform: `translate(1.75rem,-5.75rem)`,
           content: '""',
           backgroundImage: `linear-gradient(45deg, #B17ACC 16.67%, #ffffff 16.67%, #ffffff 50%, #B17ACC 50%, #B17ACC 66.67%, #ffffff 66.67%, #ffffff 100%)`,
           backgroundSize: `4.24px 4.24px`,
@@ -48,7 +47,7 @@ const Callout = ({ node }) => {
         <li>Themes Docs</li>
         <li>Official Blog Theme on GitHub</li>
       </ul> */}
-      <PortableText blocks={node.calloutContent} />
+      <PortableText blocks={node.content} />
     </div>
   );
 };

--- a/site/src/components/Footer.js
+++ b/site/src/components/Footer.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Styled } from 'theme-ui';
 import { FaGithub, FaTwitter } from 'react-icons/fa';
+import { graphql, useStaticQuery } from 'gatsby';
 
 import MagentaBlue from '../assets/pattern/magenta+blue.png';
 
@@ -19,6 +20,30 @@ const StyledLink = ({ children, ...props }) => (
 );
 
 const Footer = () => {
+  const data = useStaticQuery(graphql`
+    query {
+      site {
+        siteMetadata {
+          footer {
+            blurb
+            links {
+              link
+              name
+              icon
+            }
+          }
+        }
+      }
+    }
+  `);
+
+  const { blurb, links } = data.site.siteMetadata.footer;
+
+  const icons = {
+    twitter: FaTwitter,
+    github: FaGithub,
+  };
+
   return (
     <footer sx={{ textAlign: 'left' }}>
       <img
@@ -32,12 +57,7 @@ const Footer = () => {
           zIndex: '0',
         }}
       />
-      <Styled.p sx={{ color: 'text.1' }}>
-        Gatsby is a modern website framework that builds performance into every
-        website by leveraging the latest web technologies. Create blazing fast,
-        compelling apps and websites without needing to become a performance
-        expert.
-      </Styled.p>
+      <Styled.p sx={{ color: 'text.1' }}>{blurb}</Styled.p>
       <Styled.ul
         sx={{
           display: 'flex',
@@ -49,7 +69,18 @@ const Footer = () => {
           },
         }}
       >
-        <Styled.li>
+        {links.map(link => {
+          const Icon = link.icon ? icons[link.icon] : null;
+
+          return (
+            <Styled.li key={link.url}>
+              <StyledLink href={link.url}>
+                {Icon && <Icon />} {link.name}
+              </StyledLink>
+            </Styled.li>
+          );
+        })}
+        {/* <Styled.li>
           <StyledLink href="https://www.gatsbyjs.org">gatsbyjs.org</StyledLink>
         </Styled.li>
         <Styled.li>
@@ -62,7 +93,7 @@ const Footer = () => {
             <FaTwitter />
             gatsbyjs
           </StyledLink>
-        </Styled.li>
+        </Styled.li> */}
       </Styled.ul>
     </footer>
   );

--- a/site/src/gatsby-theme-marketing-sanity/components/serializers.js
+++ b/site/src/gatsby-theme-marketing-sanity/components/serializers.js
@@ -12,7 +12,7 @@ export default {
   types: {
     // if you want to change headings, etc., you have to edit this component
     callout: Callout,
-    codeBlock: CodeBlock,
+    code: CodeBlock,
     block: BlockRenderer,
     'page-image': Figure,
     rule: Rule,

--- a/site/src/gatsby-theme-marketing-sanity/theme.js
+++ b/site/src/gatsby-theme-marketing-sanity/theme.js
@@ -3,7 +3,7 @@ import { merge } from 'lodash';
 
 // shadowing the base theme defined in the marketing theme to override design tokens
 export const theme = merge(baseTheme, {
-  space: [0, 4, 8, 16, 32],
+  space: [0, 4, 8, 16, 32, 64, 128],
   breakpoints: ['750px'],
   fonts: {
     heading: `Futura PT`,


### PR DESCRIPTION
- use theme-ui for margins instead of rems
- update name of the `code` block
- add a preview in Sanity for callout sections
- change "Page" to "Pages" for Sanity menu item to be a bit more helpful
- switch the footer over to use site metadata instead