### PR TITLE
move react-helmet links to page from layout

### DIFF
--- a/site/src/gatsby-theme-marketing-sanity/components/layout.js
+++ b/site/src/gatsby-theme-marketing-sanity/components/layout.js
@@ -17,18 +17,6 @@ const Layout = ({ title, description, children }) => {
       <Helmet>
         <title>{meta.title}</title>
         <meta name="description" content={description} />
-        <html lang="en-US" />
-        <link href="https://cdn.sanity.io/" rel="preconnect" crossorigin />
-        <link
-          rel="preload"
-          href="/static/ftn65-webfont-0ddc10d20bd3c3e162e4ea9b49c82856.woff2"
-          as="font"
-        />
-        <link
-          rel="preload"
-          href="/static/ftn45-webfont-c2439033a37a428d148b673062131f47.woff2"
-          as="font"
-        />
       </Helmet>
       <Header />
       <Main>

--- a/site/src/gatsby-theme-marketing-sanity/components/page.js
+++ b/site/src/gatsby-theme-marketing-sanity/components/page.js
@@ -28,6 +28,18 @@ const Page = ({ slug, title, description, image, content }) => {
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         {image && <meta name="twitter:image" content={image} />}
+        <html lang="en-US" />
+        <link href="https://cdn.sanity.io/" rel="preconnect" crossorigin />
+        <link
+          rel="preload"
+          href="/static/ftn65-webfont-0ddc10d20bd3c3e162e4ea9b49c82856.woff2"
+          as="font"
+        />
+        <link
+          rel="preload"
+          href="/static/ftn45-webfont-c2439033a37a428d148b673062131f47.woff2"
+          as="font"
+        />
       </Helmet>
       <PortableText blocks={content} />
       <Illustrations slug={slug} />


### PR DESCRIPTION
For whatever reason I don't understand, the links in `react-helmet` when in the layout file aren't showing up in the elements tab in develop.

Moving them to the page component has them showing up which I think should help with those performance adjustments.